### PR TITLE
chore: this pr adds specs for the auth validation

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,24 @@
+name: Ruby
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint_and_test:
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 1
+    env:
+      RACK_ENV: test
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Run rake (lint and test)
+        run: ruby test/test_runner.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,9 @@ Metrics/BlockLength:
     - "spec/**/*"
     - "test/**/*"
     - "app.rb"
+
+Metrics/MethodLength:
+  Exclude:
+    - "spec/**/*"
+    - "test/**/*"
+    - "app.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,6 @@ group :development do
   gem 'rubocop', '~> 1.66'
   gem 'rubocop-performance', '~> 1.22'
   gem 'rubocop-rake', '~> 0.6.0'
+  gem 'test-unit', '~> 3.6'
+  gem 'timecop', '~> 0.9.10'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
+    power_assert (2.0.4)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -67,7 +68,10 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
+    test-unit (3.6.2)
+      power_assert
     tilt (2.4.0)
+    timecop (0.9.10)
     unicode-display_width (2.6.0)
     webrick (1.8.2)
 
@@ -86,7 +90,9 @@ DEPENDENCIES
   rubocop (~> 1.66)
   rubocop-performance (~> 1.22)
   rubocop-rake (~> 0.6.0)
+  test-unit (~> 3.6)
   tilt (~> 2.4)
+  timecop (~> 0.9.10)
 
 BUNDLED WITH
    2.5.21

--- a/app.rb
+++ b/app.rb
@@ -13,10 +13,7 @@ require_relative 'lib/auth_validator'
 
 BOT_KEY = ENV.delete('TELEGRAMBOTSECRETKEY')
 
-class AuthTooOldError < StandardError; end
-class NoSecretKeyError < StandardError; end
-
-class App < Roda
+class App < Roda # rubocop:disable Style/Documentation
   plugin :render
   plugin :head
   plugin :sessions, secret: ENV.fetch('SESSION_SECRET', SecureRandom.hex(64))

--- a/lib/auth_validator.rb
+++ b/lib/auth_validator.rb
@@ -7,27 +7,28 @@
 #   auth_validator.valid_auth?(params)
 #
 class AuthValidator
+  class AuthTooOldError < StandardError; end
+
   # Validates the Telegram Bot's secret key
   # @param [Hash] params The parameters from user after login
   # @param [String] bot_key The Telegram Bot's secret key
   #
   # @return [Boolean]
   def valid_auth?(params, bot_key)
-    raise NoSecretKeyError, 'No secret key found' unless bot_key
     raise AuthTooOldError, 'Data is outdated' if Time.now.to_i - params['auth_date'] > 86_400
 
     params_hash = params.delete('hash')
-    computed_hash = compute_hash_for_auth_data(params)
+    computed_hash = compute_hash_for_auth_data(params, bot_key)
 
     hash_equals?(params_hash, computed_hash)
   end
 
   private
 
-  def compute_hash_for_auth_data(params)
+  def compute_hash_for_auth_data(params, bot_key)
     check_string = prepare_auth_data_check_string(params)
     sha256_digest = OpenSSL::Digest.new('SHA256')
-    token_sha = sha256_digest.digest(BOT_KEY)
+    token_sha = sha256_digest.digest(bot_key)
 
     OpenSSL::HMAC.hexdigest(sha256_digest, token_sha, check_string)
   end

--- a/test/auth_validator_test.rb
+++ b/test/auth_validator_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AuthValidatorTest < Test::Unit::TestCase
+  def test_hash_authentication_with_passed_params
+    Timecop.freeze(Date.new(2011, 11, 11)) do
+      AuthValidator.new
+      params = { 'id' => 1337,
+                 'first_name' => 'Simon',
+                 'last_name' => 'Neutert',
+                 'username' => 'simonneutert',
+                 'photo_url' => 'https://t.me/i/userpic/320/xxx.jpg',
+                 'auth_date' => 1_320_966_000,
+                 'hash' => '9c82b507c611f9dd98e5a70cf0ba458d7a3dab038c9bb94219c6ecc9caa80eae' }
+      cloned_params = Marshal.load(Marshal.dump(params))
+      auth_validator = AuthValidator.new
+      auth_status = auth_validator.valid_auth?(cloned_params, '1337LeetUnitRheinhessen')
+      assert_equal(true, auth_status)
+    end
+  end
+
+  def test_hash_authentication_with_auth_too_old
+    Timecop.freeze(Date.new(2011, 11, 11)) do
+      AuthValidator.new
+      params = { 'id' => 1337,
+                 'first_name' => 'Simon',
+                 'last_name' => 'Neutert',
+                 'username' => 'simonneutert',
+                 'photo_url' => 'https://t.me/i/userpic/320/xxx.jpg',
+                 'auth_date' => 1337,
+                 'hash' => '9c82b507c611f9dd98e5a70cf0ba458d7a3dab038c9bb94219c6ecc9caa80eae' }
+      cloned_params = Marshal.load(Marshal.dump(params))
+      auth_validator = AuthValidator.new
+
+      assert_raise AuthValidator::AuthTooOldError do
+        auth_validator.valid_auth?(cloned_params, '1337LeetUnitRheinhessen')
+      end
+    end
+  end
+end

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# bundler setup
+require 'bundler/setup'
+Bundler.require # (:default)
+
+# spec/test requires
+require 'test/unit'
+require 'timecop'
+# app requires
+require 'dotenv/load'
+require 'digest'
+require 'openssl'
+
+# require business logic
+Dir.glob('lib/*.rb').each { |file| require_relative "../#{file}" }
+
+# require test files, results in running all tests
+Dir.glob('test/*_test.rb').each { |file| require_relative "../#{file}" }


### PR DESCRIPTION
why not use [test-unit](https://github.com/test-unit/test-unit) this time?

![image](https://github.com/user-attachments/assets/35ec3db9-bd27-4b02-96dd-de3f6da67791)


Bonus:

- [x] GitHub workflow